### PR TITLE
Fix: Add explicit types to CallHistory component

### DIFF
--- a/src/components/CallHistory.vue
+++ b/src/components/CallHistory.vue
@@ -149,7 +149,7 @@ const ranges = [
   { label: 'Past Month', value: 'month' }
 ]
 const selectedRange = ref('week')
-const expandedRows = ref({})
+const expandedRows = ref<Record<string, boolean>>({})
 
 const toggleRow = (data: any) => {
   const newExpandedRows = { ...expandedRows.value }

--- a/src/components/CallHistory.vue
+++ b/src/components/CallHistory.vue
@@ -115,6 +115,35 @@ import Badge from 'primevue/badge'
 import Button from 'primevue/button'
 import SessionDetails from './SessionDetails.vue'
 
+interface CallHistoryEntry {
+  phoneNumber: string;
+  type: string;
+  contactName: string;
+  duration: string;
+  date: Date;
+  status: string;
+}
+
+interface CallDetailField {
+  label: string;
+  key: keyof CallHistoryEntry;
+}
+
+const selectedCall = ref<CallHistoryEntry | null>(null);
+
+const callDetailFields: CallDetailField[] = [
+  { label: 'Phone Number', key: 'phoneNumber' },
+  { label: 'Call Type', key: 'type' },
+];
+
+const selectedDetails = computed(() => {
+  if (!selectedCall.value) return [];
+  return callDetailFields.map((field) => ({
+    label: field.label,
+    value: selectedCall.value![field.key],
+  }));
+});
+
 const ranges = [
   { label: 'Past Week', value: 'week' },
   { label: 'Past Month', value: 'month' }


### PR DESCRIPTION
### Purpose

This pull request addresses a Netlify deployment failure caused by a TypeScript error in the `CallHistory` component. The build was failing because a `CallHistoryEntry` object was being indexed by a value with an implicit `any` type. The goal was to resolve this build-blocking issue by explicitly typing the relevant data structures.

### Code changes

- **Added `CallHistoryEntry` and `CallDetailField` interfaces:** Introduced explicit types for call history entries and the fields used to display their details.
- **Typed `selectedCall` and `expandedRows`:** Applied the new types to the `selectedCall` and `expandedRows` refs to improve type safety.
- **Updated `selectedDetails` computed property:** Modified the logic to use the strongly-typed `callDetailFields` array, ensuring that the indexing of `selectedCall.value` is type-safe and preventing the TypeScript error.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/252762bfc0bd4bb7bb267f46e784c261/flare-lab)

👀 [Preview Link](https://252762bfc0bd4bb7bb267f46e784c261-flare-lab.projects.builder.my/)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 47`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>252762bfc0bd4bb7bb267f46e784c261</projectId>-->
<!--<branchName>flare-lab</branchName>-->